### PR TITLE
feat: add decisionScopes config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,9 @@ async function loadEager(doc) {
     {
       personalization: !!getMetadata('target') && isConsentGiven,
       launchUrls: [/* your Launch script URLs here */],
+      // To request additional decision scopes beyond the default `__view__` scope,
+      // list them here. They are added to the eager personalization fetch.
+      // decisionScopes: ['my-scope-name'],
       // See the API Reference for all available options.
     },
   );
@@ -253,6 +256,7 @@ Initializes the library. This should be called once in `loadEager`.
   - `personalizationTimeout` `{Number}`: Timeout in ms for personalization. Default: `1000`.
   - `trackPageView` `{Boolean}`: Whether to automatically send a page view event on page activation. When `false`, the library sends a `decisioning.propositionDisplay` event instead, so proposition display is still reported to Target without triggering an extra page view. Set to `false` if this is already handled separately in the page. Default: `true`.
   - `shouldProcessEvent` `{Function}`: A function that receives a data layer event payload and returns `false` to prevent it from being sent.
+  - `decisionScopes` `{String[]}`: Additional decision scopes to request beyond the default `__view__` scope. Previously this required mutating the payload via `onBeforeEventSend`; this provides a dedicated config field. The scopes are included in both the eager `propositionFetch` (when `performanceOptimized` is `true`) and the `martechLazy` `sendEvent` (when `performanceOptimized` is `false`), with `__view__` always included. Default: `[]`.
 
 ---
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,13 @@
  *                                         and returns a boolean. Return true to process the event,
  *                                         false to ignore it. The default is a function that
  *                                         always returns true.
+ * @property {String[]} [decisionScopes]   Additional decision scopes to request beyond the
+ *                                         default `__view__` scope. The scopes are included
+ *                                         in both the eager `propositionFetch` (performance
+ *                                         path) and the `martechLazy` `sendEvent`
+ *                                         (non-performance path), with `__view__` always
+ *                                         included.
+ *                                         (defaults to [])
  */
 export const DEFAULT_CONFIG = {
   analytics: true,
@@ -46,6 +53,7 @@ export const DEFAULT_CONFIG = {
   performanceOptimized: true,
   personalizationTimeout: 1000,
   shouldProcessEvent: () => true,
+  decisionScopes: [],
 };
 
 let config;
@@ -394,6 +402,7 @@ async function applyPropositions(instanceName) {
     renderDecisions: false,
     personalization: {
       sendDisplayEvent: false,
+      ...(config.decisionScopes?.length && { decisionScopes: config.decisionScopes }),
     },
   });
   response = renderDecisionResponse;
@@ -636,7 +645,10 @@ export async function martechLazy() {
       });
     }
   } else if (!config.performanceOptimized) {
-    const renderDecisionResponse = await sendEvent({ renderDecisions: true, decisionScopes: ['__view__'] });
+    const renderDecisionResponse = await sendEvent({
+      renderDecisions: true,
+      decisionScopes: [...new Set(['__view__', ...(config.decisionScopes || [])])],
+    });
     response = renderDecisionResponse;
     document.body.style.visibility = null;
     // Automatically report displayed propositions


### PR DESCRIPTION
## Summary

The Web SDK only fetches `__view__` propositions by default. Consumers that need additional decision scopes have historically mutated the request payload via the `onBeforeEventSend` handler; a dedicated config field is cleaner and more discoverable (per reviewer feedback on #17).

Adds an optional `decisionScopes: String[]` field to `MartechConfig`:

- **Performance path** (`applyPropositions` → `decisioning.propositionFetch`): spread into `personalization.decisionScopes` only when non-empty, so the default fetch is byte-identical for consumers that don't set it.
- **Non-performance path** (`martechLazy` → `sendEvent` with `renderDecisions: true`): merged with `__view__` and de-duped via `Set`. `renderDecisions: true` requires `__view__` to be listed explicitly when passing `decisionScopes`, so both are always included.

Backwards-compatible: default is `[]`, behavior unchanged for consumers that omit it.

### Usage

```js
initMartech(
  webSDKConfig,
  {
    personalization: true,
    decisionScopes: ['my-scope-name'],
  },
);
```

### Context

This was originally part of #17 (broader proposition-handling work). Per reviewer feedback that the `decisionScopes` API is a "good general improvement that would serve most customers," it's being submitted as a standalone PR off `main` so it can land independently of the larger work on #17, which is still iterating.

## Test plan

- [x] `npm run lint` passes.
- [ ] Default consumer (no `decisionScopes`): `propositionFetch` payload is unchanged (no new `personalization.decisionScopes` key on the wire).
- [ ] `decisionScopes: ['my-scope']` on the performance path: the named scope appears in the `propositionFetch` request body.
- [ ] `decisionScopes: ['my-scope']` on the non-performance path (`performanceOptimized: false`): `sendEvent` is called with `decisionScopes: ['__view__', 'my-scope']` (de-duped, `__view__` always present).
- [ ] `decisionScopes: ['__view__', 'my-scope']` (consumer redundantly includes `__view__`): `__view__` is not duplicated.